### PR TITLE
fix console errors

### DIFF
--- a/src/containers/MuiTheme.js
+++ b/src/containers/MuiTheme.js
@@ -11,8 +11,9 @@ import ThemeSideBar from '../components/ThemeSideBar';
 
 const propTypes = {
     themesAppliedListInit: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
-    themeName: React.PropTypes.string.isRequired,
-    themeNameArr: React.PropTypes.arrayOf(React.PropTypes.string).isRequired,
+    //themeName: React.PropTypes.string.isRequired,
+    //themeNameArr: React.PropTypes.arrayOf(React.PropTypes.string).isRequired, 
+    //These two props should not be required, they aren't being passed through and it is throwing a console error 
     story: React.PropTypes.object.isRequired,
     onChangeState: React.PropTypes.func.isRequired,
     onThemeOverride: React.PropTypes.func.isRequired,


### PR DESCRIPTION
console was throwing error regarding themeName and themeNameArr being required. Defining those values didn't matter, as it wasn't accepting or using them as far as i could tell, so i just removed the propTypes and it fixed the error